### PR TITLE
Ability to add custom job held text

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursConfig.java
@@ -140,9 +140,9 @@ public class WorkingHoursConfig extends GlobalConfiguration {
     /**
      * Gets the message to be displayed when the job is blocked
      *
-     * @return default message if the value is null
+     * @return custom message or the default message, if the custom message is null.
      */
-    public String getCustomJobHoldText() {
+    public String getJobHoldText() {
         return customJobHoldText == null
                 ? Messages.WorkingHoursQueueTaskDispatcher_Offline()
                 : customJobHoldText;

--- a/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursConfig.java
@@ -52,6 +52,11 @@ public class WorkingHoursConfig extends GlobalConfiguration {
     private List<ExcludedDate> excludedDates;
 
     /**
+     *  Custom string to display when job is blocked
+     */
+    private String blockedJobText;
+
+    /**
      * Default times for new configurations.
      */
     private final TimeRange[] defaultConfig = {
@@ -129,6 +134,26 @@ public class WorkingHoursConfig extends GlobalConfiguration {
     public void setExcludedDates(
             @CheckForNull List<ExcludedDate> value) {
         this.excludedDates = value;
+        save();
+    }
+
+    /**
+     * Gets the message to be displayed when the job is blocked
+     *
+     * @return default message if the value is null
+     */
+    public String getBlockedJobText() {
+        return blockedJobText == null
+                ? Messages._WorkingHoursQueueTaskDispatcher_Offline().toString()
+                : blockedJobText;
+    }
+
+    /**
+     *  Sets new string to display when jobs are blocked
+     * @param blockedJobText
+     */
+    public void setBlockedJobText(String blockedJobText) {
+        this.blockedJobText = blockedJobText;
         save();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursConfig.java
@@ -144,7 +144,7 @@ public class WorkingHoursConfig extends GlobalConfiguration {
      */
     public String getCustomJobHoldText() {
         return customJobHoldText == null
-                ? Messages._WorkingHoursQueueTaskDispatcher_Offline().toString()
+                ? Messages.WorkingHoursQueueTaskDispatcher_Offline()
                 : customJobHoldText;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursConfig.java
@@ -150,7 +150,7 @@ public class WorkingHoursConfig extends GlobalConfiguration {
 
     /**
      *  Sets new string to display when jobs are blocked
-     * @param customJobHoldText
+     * @param customJobHoldText string to use as the jobHeldDescription
      */
     public void setCustomJobHoldText(String customJobHoldText) {
         this.customJobHoldText = customJobHoldText.trim().length() > 0 ? customJobHoldText : null;

--- a/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursConfig.java
@@ -54,7 +54,7 @@ public class WorkingHoursConfig extends GlobalConfiguration {
     /**
      *  Custom string to display when job is blocked
      */
-    private String blockedJobText;
+    private String customJobHoldText;
 
     /**
      * Default times for new configurations.
@@ -142,18 +142,18 @@ public class WorkingHoursConfig extends GlobalConfiguration {
      *
      * @return default message if the value is null
      */
-    public String getBlockedJobText() {
-        return blockedJobText == null
+    public String getCustomJobHoldText() {
+        return customJobHoldText == null
                 ? Messages._WorkingHoursQueueTaskDispatcher_Offline().toString()
-                : blockedJobText;
+                : customJobHoldText;
     }
 
     /**
      *  Sets new string to display when jobs are blocked
-     * @param blockedJobText
+     * @param customJobHoldText
      */
-    public void setBlockedJobText(String blockedJobText) {
-        this.blockedJobText = blockedJobText;
+    public void setCustomJobHoldText(String customJobHoldText) {
+        this.customJobHoldText = customJobHoldText.trim().length() > 0 ? customJobHoldText : null;
         save();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursQueueTaskDispatcher.java
+++ b/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursQueueTaskDispatcher.java
@@ -84,7 +84,7 @@ public class WorkingHoursQueueTaskDispatcher extends QueueTaskDispatcher {
                     return new CauseOfBlockage() {
                         @Override
                         public String getShortDescription() {
-                            return WorkingHoursConfig.get().getCustomJobHoldText();
+                            return WorkingHoursConfig.get().getJobHoldText();
                         }
                     };
                 }

--- a/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursQueueTaskDispatcher.java
+++ b/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursQueueTaskDispatcher.java
@@ -81,7 +81,12 @@ public class WorkingHoursQueueTaskDispatcher extends QueueTaskDispatcher {
             if (prop != null) {
                 if (!canRunNow(workflowRun, item)) {
                     log(Level.INFO, "Blocking item %d", item.getId());
-                    return CauseOfBlockage.fromMessage(Messages._WorkingHoursQueueTaskDispatcher_Offline());
+                    return new CauseOfBlockage() {
+                        @Override
+                        public String getShortDescription() {
+                            return WorkingHoursConfig.get().getCustomJobHoldText();
+                        }
+                    };
                 }
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursQueueTaskDispatcher.java
+++ b/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursQueueTaskDispatcher.java
@@ -91,7 +91,7 @@ public class WorkingHoursQueueTaskDispatcher extends QueueTaskDispatcher {
                             public String getShortDescription() {
                                 return WorkingHoursConfig.get().getJobHoldText();
                             }
-                        }
+                        };
                     }
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursQueueTaskDispatcher.java
+++ b/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursQueueTaskDispatcher.java
@@ -90,6 +90,7 @@ public class WorkingHoursQueueTaskDispatcher extends QueueTaskDispatcher {
                             @Override
                             public String getShortDescription() {
                                 return WorkingHoursConfig.get().getJobHoldText();
+                            }
                         }
                     }
                 }

--- a/src/main/resources/org/jenkinsci/plugins/workinghours/WorkingHoursConfig/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workinghours/WorkingHoursConfig/config.jelly
@@ -11,8 +11,8 @@
         <f:repeatableProperty field="excludedDates" />
     </f:entry>
 
-      <f:entry title="Message to show when jobs are held" >
-          <f:textbox field="blockedJobText" />
+      <f:entry title="Message to show when jobs are held" field="customJobHoldText">
+          <f:textbox field="customJobHoldText" />
       </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workinghours/WorkingHoursConfig/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workinghours/WorkingHoursConfig/config.jelly
@@ -10,6 +10,9 @@
     <f:entry title="Excluded dates">
         <f:repeatableProperty field="excludedDates" />
     </f:entry>
-    
+
+      <f:entry title="Message to show when jobs are held" >
+          <f:textbox field="blockedJobText" />
+      </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workinghours/WorkingHoursConfig/help-customJobHoldText.html
+++ b/src/main/resources/org/jenkinsci/plugins/workinghours/WorkingHoursConfig/help-customJobHoldText.html
@@ -1,0 +1,3 @@
+<div>
+    Displays a custom message when the job is being held. Uses the default text if left empty.
+</div>


### PR DESCRIPTION
In reference to #4 to introduce the ability to add custom job held text

- [X]  Update layout to add a custom text field
- [X] Create methods to handle the custom texts
- [X] Replace direct call to `Messages` to `WorkingHoursConfig` for the custom text.
