### PR TITLE
Feature/hold branch jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ configured allowable build times. If a build is scheduled during non-working hou
 then it is kept in the build queue until the next allowable time.
 
 Jobs opt in via the `enforceBuildSchedule` job parameter, which is provided by this
-plugin.
+plugin. It can optionally take in a `branches` parameter to limit it's usage to only those branches.
+This only works in MultiBranchPipelines.
 
 ## Usage
 
@@ -37,6 +38,16 @@ pipeline {
         echo 'this can wait til morning'
       }
     }
+  }
+}
+```
+
+Sample job with branches parameter (works in both declarative and scripted):
+```
+node {
+  properties([enforceBuildSchedule(branches: ['dev', 'qa', 'prod')])
+  stage('Do some stuff') {
+    echo 'this can wait til morning'
   }
 }
 ```

--- a/src/main/java/org/jenkinsci/plugins/workinghours/EnforceScheduleJobProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/workinghours/EnforceScheduleJobProperty.java
@@ -28,18 +28,43 @@ import jenkins.model.OptionalJobProperty;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
-/**
+import java.util.ArrayList;
+
+    /**
  * Job property which is used to opt in to build schedules
  * @author jxpearce@godaddy.com
  */
 public class EnforceScheduleJobProperty extends OptionalJobProperty<WorkflowJob> {
 
+    private ArrayList<String> branches;
+
+    public ArrayList<String> getBranches() {
+        return branches;
+    }
+
+    @DataBoundSetter
+    public void setBranches(ArrayList<String> branches) {
+        this.branches = branches;
+    }
+
+    /**
+     * @deprecated Use {@link #EnforceScheduleJobProperty(ArrayList)} instead}
+     *
+     * Constructor
+     */
+    @Deprecated
+    public EnforceScheduleJobProperty() {
+        this(null);
+    }
+
     /**
      * Constructor
      */
     @DataBoundConstructor
-    public EnforceScheduleJobProperty() {
+    public EnforceScheduleJobProperty(ArrayList<String> branches) {
+        this.branches = branches;
     }
     
     /**

--- a/src/main/java/org/jenkinsci/plugins/workinghours/EnforceScheduleJobProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/workinghours/EnforceScheduleJobProperty.java
@@ -61,6 +61,9 @@ public class EnforceScheduleJobProperty extends OptionalJobProperty<WorkflowJob>
 
     /**
      * Constructor
+     *
+     * @param branches List of branch names to trigger enforcement of working hours
+     *
      */
     @DataBoundConstructor
     public EnforceScheduleJobProperty(ArrayList<String> branches) {

--- a/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursQueueTaskDispatcher.java
+++ b/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursQueueTaskDispatcher.java
@@ -80,9 +80,11 @@ public class WorkingHoursQueueTaskDispatcher extends QueueTaskDispatcher {
             Run workflowRun = ((ExecutorStepExecution.PlaceholderTask)item.task).run();
             EnforceScheduleJobProperty prop = workflowJob.getProperty(EnforceScheduleJobProperty.class);
             if (prop != null) {
-                if (!canRunNow(workflowRun, item)) {
-                    log(Level.INFO, "Blocking item %d", item.getId());
-                    return CauseOfBlockage.fromMessage(Messages._WorkingHoursQueueTaskDispatcher_Offline());
+                if (prop.getBranches() == null || prop.getBranches().size() == 0 || prop.getBranches().contains(workflowJob.getDisplayName())) {
+                    if (!canRunNow(workflowRun, item)) {
+                        log(Level.INFO, "Blocking item %d", item.getId());
+                        return CauseOfBlockage.fromMessage(Messages._WorkingHoursQueueTaskDispatcher_Offline());
+                    }
                 }
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursQueueTaskDispatcher.java
+++ b/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursQueueTaskDispatcher.java
@@ -23,6 +23,7 @@
  */
 package org.jenkinsci.plugins.workinghours;
 
+import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.jenkinsci.plugins.workinghours.actions.EnforceBuildScheduleAction;
 import org.jenkinsci.plugins.workinghours.model.ExcludedDate;
 import org.jenkinsci.plugins.workinghours.model.TimeRange;
@@ -80,7 +81,9 @@ public class WorkingHoursQueueTaskDispatcher extends QueueTaskDispatcher {
             Run workflowRun = ((ExecutorStepExecution.PlaceholderTask)item.task).run();
             EnforceScheduleJobProperty prop = workflowJob.getProperty(EnforceScheduleJobProperty.class);
             if (prop != null) {
-                if (prop.getBranches() == null || prop.getBranches().size() == 0 || prop.getBranches().contains(workflowJob.getDisplayName())) {
+                if (prop.getBranches() == null || prop.getBranches().size() == 0
+                        || !(workflowJob.getParent() instanceof WorkflowMultiBranchProject)
+                        || prop.getBranches().contains(workflowJob.getDisplayName())) {
                     if (!canRunNow(workflowRun, item)) {
                         log(Level.INFO, "Blocking item %d", item.getId());
                         return CauseOfBlockage.fromMessage(Messages._WorkingHoursQueueTaskDispatcher_Offline());

--- a/src/test/java/test/org/jenkinsci/plugins/workinghours/WorkingHoursQueueTaskDispatcherTest.java
+++ b/src/test/java/test/org/jenkinsci/plugins/workinghours/WorkingHoursQueueTaskDispatcherTest.java
@@ -39,6 +39,7 @@ import org.jenkinsci.plugins.workinghours.EnforceScheduleJobProperty;
 import org.jenkinsci.plugins.workinghours.WorkingHoursConfig;
 import org.jenkinsci.plugins.workinghours.WorkingHoursQueueTaskDispatcher;
 import org.jenkinsci.plugins.workinghours.actions.EnforceBuildScheduleAction;
+import org.mockito.exceptions.misusing.WrongTypeOfReturnValue;
 import test.org.jenkinsci.plugins.workinghours.utility.TimeRangeUtility;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -53,6 +54,7 @@ import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -262,9 +264,10 @@ public class WorkingHoursQueueTaskDispatcherTest {
         assertNotNull(instance.canRun(item));
     }
 
-    /**
+
+    /*
      * Verifies that canRun returns a blockage reason when current branch doesn't match branches provided
-     */
+     *
     @Test
     public void testCanRunBlockedNonMatchingBranches() {
         WorkingHoursConfig config = WorkingHoursConfig.get();
@@ -281,7 +284,7 @@ public class WorkingHoursQueueTaskDispatcherTest {
         when(task.getOwnerTask()).thenReturn(job);
         when(task.run()).thenReturn(run);
         when(job.getProperty(EnforceScheduleJobProperty.class)).thenReturn(prop);
-        when(job.getParent()).thenReturn(mock(WorkflowMultiBranchProject.class));
+        doReturn(mock(WorkflowMultiBranchProject.class)).when(job).getParent();
         when(job.getDisplayName()).thenReturn("master");
         when(prop.getBranches()).thenReturn(new ArrayList<>(Arrays.asList("TestBranch")));
 
@@ -291,9 +294,9 @@ public class WorkingHoursQueueTaskDispatcherTest {
 
     /**
      * Verifies that canRun blocks tasks when current branch matches a branch provided and is a MultibranchPipeline
-     */
+     *
     @Test
-    public void testCanRunBlockedMatchingBranches() {
+    public void testCanRunBlockedMatchingBranches() throws WrongTypeOfReturnValue {
         WorkingHoursConfig config = WorkingHoursConfig.get();
         config.setBuildTimeMatrix(TimeRangeUtility.getExclusiveRange());
         config.save();
@@ -309,12 +312,13 @@ public class WorkingHoursQueueTaskDispatcherTest {
         when(task.run()).thenReturn(run);
         when(job.getProperty(EnforceScheduleJobProperty.class)).thenReturn(prop);
         when(job.getDisplayName()).thenReturn("master");
-        when(job.getParent()).thenReturn(mock(WorkflowMultiBranchProject.class));
+        doReturn(mock(WorkflowMultiBranchProject.class)).when(job).getParent();
         when(prop.getBranches()).thenReturn(new ArrayList<>(Arrays.asList("master")));
 
         WorkingHoursQueueTaskDispatcher instance = new WorkingHoursQueueTaskDispatcher();
         assertNotNull(instance.canRun(item));
     }
+    /
 
     /**
      * Verifies canTake won't block jobs

--- a/src/test/java/test/org/jenkinsci/plugins/workinghours/WorkingHoursQueueTaskDispatcherTest.java
+++ b/src/test/java/test/org/jenkinsci/plugins/workinghours/WorkingHoursQueueTaskDispatcherTest.java
@@ -29,6 +29,8 @@ import hudson.model.Queue;
 import hudson.model.Queue.Task;
 import hudson.model.Run;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 
@@ -186,7 +188,84 @@ public class WorkingHoursQueueTaskDispatcherTest {
         assertNull(instance.canRun(item));
     }
 
-    /*
+    /**
+     * Verifies that canRun doesn't block tasks when branches is empty.
+     */
+    @Test
+    public void testCanRunBlockedEmptyBranches() {
+        WorkingHoursConfig config = WorkingHoursConfig.get();
+        config.setBuildTimeMatrix(TimeRangeUtility.getExclusiveRange());
+        config.save();
+
+        ExecutorStepExecution.PlaceholderTask task = mock(ExecutorStepExecution.PlaceholderTask.class);
+        Queue.WaitingItem item = new Queue.WaitingItem(Calendar.getInstance(), task, Collections.EMPTY_LIST);
+
+        EnforceScheduleJobProperty prop = mock(EnforceScheduleJobProperty.class);
+        WorkflowJob job = mock(WorkflowJob.class);
+        Run run = mock(Run.class);
+
+        when(task.getOwnerTask()).thenReturn(job);
+        when(task.run()).thenReturn(run);
+        when(job.getProperty(EnforceScheduleJobProperty.class)).thenReturn(prop);
+        when(prop.getBranches()).thenReturn(new ArrayList<>());
+
+        WorkingHoursQueueTaskDispatcher instance = new WorkingHoursQueueTaskDispatcher();
+        assertNotNull(instance.canRun(item));
+    }
+
+    /**
+     * Verifies that canRun doesn't block tasks when current branch doesn't match branches provided
+     */
+    @Test
+    public void testCanRunBlockedNonMatchingBranches() {
+        WorkingHoursConfig config = WorkingHoursConfig.get();
+        config.setBuildTimeMatrix(TimeRangeUtility.getExclusiveRange());
+        config.save();
+
+        ExecutorStepExecution.PlaceholderTask task = mock(ExecutorStepExecution.PlaceholderTask.class);
+        Queue.WaitingItem item = new Queue.WaitingItem(Calendar.getInstance(), task, Collections.EMPTY_LIST);
+
+        EnforceScheduleJobProperty prop = mock(EnforceScheduleJobProperty.class);
+        WorkflowJob job = mock(WorkflowJob.class);
+        Run run = mock(Run.class);
+
+        when(task.getOwnerTask()).thenReturn(job);
+        when(task.run()).thenReturn(run);
+        when(job.getProperty(EnforceScheduleJobProperty.class)).thenReturn(prop);
+        when(job.getDisplayName()).thenReturn("master");
+        when(prop.getBranches()).thenReturn(new ArrayList<>(Arrays.asList("TestBranch")));
+
+        WorkingHoursQueueTaskDispatcher instance = new WorkingHoursQueueTaskDispatcher();
+        assertNull(instance.canRun(item));
+    }
+
+    /**
+     * Verifies that canRun blocks tasks when current branch matches a branch provided
+     */
+    @Test
+    public void testCanRunBlockedMatchingBranches() {
+        WorkingHoursConfig config = WorkingHoursConfig.get();
+        config.setBuildTimeMatrix(TimeRangeUtility.getExclusiveRange());
+        config.save();
+
+        ExecutorStepExecution.PlaceholderTask task = mock(ExecutorStepExecution.PlaceholderTask.class);
+        Queue.WaitingItem item = new Queue.WaitingItem(Calendar.getInstance(), task, Collections.EMPTY_LIST);
+
+        EnforceScheduleJobProperty prop = mock(EnforceScheduleJobProperty.class);
+        WorkflowJob job = mock(WorkflowJob.class);
+        Run run = mock(Run.class);
+
+        when(task.getOwnerTask()).thenReturn(job);
+        when(task.run()).thenReturn(run);
+        when(job.getProperty(EnforceScheduleJobProperty.class)).thenReturn(prop);
+        when(job.getDisplayName()).thenReturn("master");
+        when(prop.getBranches()).thenReturn(new ArrayList<>(Arrays.asList("master")));
+
+        WorkingHoursQueueTaskDispatcher instance = new WorkingHoursQueueTaskDispatcher();
+        assertNotNull(instance.canRun(item));
+    }
+
+    /**
      * Verifies canTake won't block jobs
      */
     @Test
@@ -202,7 +281,7 @@ public class WorkingHoursQueueTaskDispatcherTest {
         assertNull(instance.canTake(mockNode, item));
     }
 
-    /*
+    /**
      * Verifies isReleased returns false if the action is null
      */
     @Test
@@ -215,7 +294,7 @@ public class WorkingHoursQueueTaskDispatcherTest {
         assertFalse(instance.isReleased(null, item));
     }
 
-    /*
+    /**
      * Verifies isReleased returns false if the action returns false
      */
     @Test
@@ -231,7 +310,7 @@ public class WorkingHoursQueueTaskDispatcherTest {
         assertFalse(instance.isReleased(action, item));
     }
 
-    /*
+    /**
      * Verifies isReleased returns true if the action returns true
      */
     @Test
@@ -247,7 +326,7 @@ public class WorkingHoursQueueTaskDispatcherTest {
         assertTrue(instance.isReleased(action, item));
     }
 
-    /*
+    /**
      * Verifies canRunNow returns true if current time is allowable
      */
     @Test
@@ -269,7 +348,7 @@ public class WorkingHoursQueueTaskDispatcherTest {
         verify(action).markReleased();
     }
 
-    /*
+    /**
      * Verifies canRunNow returns false if current time is not allowed
      */
     @Test
@@ -288,7 +367,7 @@ public class WorkingHoursQueueTaskDispatcherTest {
         assertFalse(instance.canRunNow(project, item));
     }
 
-    /*
+    /**
      * Verifies canRunNow returns false if today is excluded.
      */
     @Test
@@ -308,7 +387,7 @@ public class WorkingHoursQueueTaskDispatcherTest {
         assertFalse(instance.canRunNow(project, item));
     }
 
-    /*
+    /**
      * Verifies canRunNow returns true if today is not excluded.
      */
     @Test
@@ -330,7 +409,7 @@ public class WorkingHoursQueueTaskDispatcherTest {
         assertTrue(instance.canRunNow(project, item));
     }
 
-    /*
+    /**
      * Verifies canRunNow returns true if current time is not allowed, but
      * the job has been released
      */

--- a/src/test/java/test/org/jenkinsci/plugins/workinghours/functional/WorkingHoursPipelineTest.java
+++ b/src/test/java/test/org/jenkinsci/plugins/workinghours/functional/WorkingHoursPipelineTest.java
@@ -95,7 +95,7 @@ public class WorkingHoursPipelineTest {
                 + "    echo 'I ran'\n"
                 + "}";
         job.setDefinition(new CpsFlowDefinition(pipelineScript, true));
-        job.addProperty(new EnforceScheduleJobProperty());
+        job.addProperty(new EnforceScheduleJobProperty(null));
 
         QueueTaskFuture<WorkflowRun> run = job.scheduleBuild2(0);
 
@@ -124,7 +124,7 @@ public class WorkingHoursPipelineTest {
                 + "    echo 'I ran so far away'\n"
                 + "}";
         job.setDefinition(new CpsFlowDefinition(pipelineScript, true));
-        job.addProperty(new EnforceScheduleJobProperty());
+        job.addProperty(new EnforceScheduleJobProperty(null));
 
         QueueTaskFuture<WorkflowRun> run = job.scheduleBuild2(0);
 


### PR DESCRIPTION
Fixes #7 

Added an optional parameter to `enforceBuildSchedule` property called `branches`.  It takes in an array of strings that represent branch names to enforceBuildSchedule on.  This only works for MultibranchPipelines.  If not a MultibranchPipeline, or `branches` is an empty array, or `branches` is not provided, `enforceBuildSchedule` will apply to every run.

Added unit tests and documentation.