### PR TITLE
Prevent null reference exception after restart

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <version>1.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.73.3</jenkins.version>
+        <jenkins.version>2.150.1</jenkins.version>
         <java.level>8</java.level>
     </properties>
     <name>Working Hours Plugin</name>
@@ -27,12 +27,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.26</version>
+            <version>1.39</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.14</version>
+            <version>1.17</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -42,12 +42,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.10</version>
+            <version>2.31</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.22</version>
+            <version>2.32</version>
         </dependency>
         <!-- he plugin doesn't explicitly use workflow-multibranch, but making
         sure we have a newer version installed lets scripted pipeline use
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.14</version>
+            <version>2.21</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -130,7 +130,6 @@
             <version>2.5</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
     <build>
         <plugins>
@@ -141,7 +140,7 @@
         <developer>
             <id>jeffpearce</id>
             <name>Jeff Pearce</name>
-            <email>jxpearce@godaddy.com</email>
+            <email>jeffpea@gmail.com</email>
         </developer>
     </developers>
 

--- a/src/main/java/org/jenkinsci/plugins/workinghours/EnforceScheduleJobProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/workinghours/EnforceScheduleJobProperty.java
@@ -34,7 +34,7 @@ import java.util.ArrayList;
 
     /**
  * Job property which is used to opt in to build schedules
- * @author jxpearce@godaddy.com
+ * @author jeffpearce
  */
 public class EnforceScheduleJobProperty extends OptionalJobProperty<WorkflowJob> {
 

--- a/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursConfig.java
@@ -36,7 +36,7 @@ import jenkins.model.GlobalConfiguration;
 /**
  * Provides configuration options for this plugin.
  *
- * @author jxpearce@godaddy.com
+ * @author jeffpearce
  */
 @Extension(optional = true)
 public class WorkingHoursConfig extends GlobalConfiguration {

--- a/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursQueueTaskDispatcher.java
+++ b/src/main/java/org/jenkinsci/plugins/workinghours/WorkingHoursQueueTaskDispatcher.java
@@ -43,14 +43,14 @@ import org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution;
 
 /**
  *
- * @author jxpearce
+ * @author jeffpearce
  */
 
 /**
  * QueueTaskDispatcher implementation that can block jobs configured with the
  * enforceBuildSchedule property outside of configured working hours.
  * 
- * @author jxpearce@godaddy.com
+ * @author jeffpearce
  */
 @Extension(optional = true)
 public class WorkingHoursQueueTaskDispatcher extends QueueTaskDispatcher {
@@ -64,12 +64,12 @@ public class WorkingHoursQueueTaskDispatcher extends QueueTaskDispatcher {
     public CauseOfBlockage canRun(Queue.Item item) {
 
         // Don't block tasks which don't have owners. This filters out both
-        // freestyle jobs and the task for the Job. The latter is important 
+        // freestyle jobs and the task for the Job. The latter is important
         // because we want to block the Run not the Job.
         if (item.task == item.task.getOwnerTask()) {
             return super.canRun(item);
         }
-        
+
         // We will only consider blocking PlaceholderTasks. We can get the
         // run directly from such tasks.
         if (!(item.task instanceof ExecutorStepExecution.PlaceholderTask)) {
@@ -126,6 +126,10 @@ public class WorkingHoursQueueTaskDispatcher extends QueueTaskDispatcher {
      */
     public boolean canRunNow(Actionable itemActionable,
             Queue.Item item) {
+
+        if (itemActionable == null || item == null) {
+            return true;
+        }
         Calendar now = Calendar.getInstance();
 
         EnforceBuildScheduleAction action = itemActionable.getAction(EnforceBuildScheduleAction.class);

--- a/src/main/java/org/jenkinsci/plugins/workinghours/actions/EnforceBuildScheduleAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workinghours/actions/EnforceBuildScheduleAction.java
@@ -32,7 +32,7 @@ import java.util.Date;
  */
 public class EnforceBuildScheduleAction extends InvisibleAction {
 
-    protected transient boolean enforcingBuildSchedule;
+    protected volatile boolean enforcingBuildSchedule;
     private long releasedTimeStamp;
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workinghours/model/DateTimeUtility.java
+++ b/src/main/java/org/jenkinsci/plugins/workinghours/model/DateTimeUtility.java
@@ -32,7 +32,7 @@ import java.time.format.DateTimeParseException;
  * Provides common methods to validate and convert date/time strings in the
  * specific formats supported by the plugin.
  *
- * @author jxpearce@godaddy.com
+ * @author jeffpearce
  */
 public final class DateTimeUtility {
     /**

--- a/src/main/java/org/jenkinsci/plugins/workinghours/model/ExcludedDate.java
+++ b/src/main/java/org/jenkinsci/plugins/workinghours/model/ExcludedDate.java
@@ -37,7 +37,7 @@ import java.util.Calendar;
 /**
  * Encapsulates an excluded date along with name for UI purposes.
  *
- * @author jxpearce@godaddy.com
+ * @author jeffpearce
  */
 public class ExcludedDate extends AbstractDescribableImpl<ExcludedDate> {
 

--- a/src/test/java/test/org/jenkinsci/plugins/workinghours/actions/EnforceBuildScheduleActionTest.java
+++ b/src/test/java/test/org/jenkinsci/plugins/workinghours/actions/EnforceBuildScheduleActionTest.java
@@ -41,7 +41,7 @@ import static org.powermock.api.mockito.PowerMockito.mock;
 
 /**
  *
- * @author jxpearce
+ * @author jeffpearce
  */
 public class EnforceBuildScheduleActionTest {
     

--- a/src/test/java/test/org/jenkinsci/plugins/workinghours/functional/WorkingHoursPipelineTest.java
+++ b/src/test/java/test/org/jenkinsci/plugins/workinghours/functional/WorkingHoursPipelineTest.java
@@ -48,7 +48,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
  *
- * @author jxpearce
+ * @author jeffpearce
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({WorkflowJob.class, WorkflowRun.class})

--- a/src/test/java/test/org/jenkinsci/plugins/workinghours/utility/TimeRangeUtility.java
+++ b/src/test/java/test/org/jenkinsci/plugins/workinghours/utility/TimeRangeUtility.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2018 jxpearce.
+ * Copyright 2018 jeffpearce.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Addresses #35 (Any running jobs fail to resume after Jenkins restart with WorkingHours plugin installed)
- Add null checks to prevent null reference exception after restart
- Fix a null pointer exception evaluating dates
- Update required jenkins version to reduce number of builds we have to support