### PR TITLE
[Hacktoberfest] Migrate docs to jenkinsci repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ In order to use the working hours plugin, you must set up a schedule in your Jen
 system configuration page. You can configure both daily working hours and specific dates (such
   as holidays). The following configuration will cause jobs with  `enforceBuildSchedule` to queue if ran outside of Monday - Friday 8:00 AM to 6:00 PM.
 
-  *Note:* all times are local to your Jenkins master.
+  *Note:* all times are local to your Jenkins controller.
 
 ![Configuration options](images/working-hours-config.png "Configuration options")
 
@@ -88,7 +88,7 @@ This section contains the times when guarded steps are allowed for each day. Tim
 - Abbreviated 24 hour eg `0900`, `1800`
 - 12 hour eg `9:00 AM`, `6:00 PM`
 
-**Note** All times are local to your Jenkins master.
+**Note** All times are local to your Jenkins controller.
 
 If the `enforceBuildStep` runs at a time that is not between a configured time range
 for the day it's running, the job will be aborted. Please note that if no allowable

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     </properties>
     <name>Working Hours Plugin</name>
     <description>Queues builds that ran after certain working hours</description>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Working-Hours-Plugin</url>
+    <url>https://github.com/jenkinsci/working-hours-plugin</url>
     <licenses>
         <license>
             <name>MIT License</name>


### PR DESCRIPTION
This PR migrates the Working Hours plugin documentation from the **plugin-wiki-docs** repo to the **working-hours-plugin** repo as part of the Hacktoberfest docs-to-code project. Since the documentation for this plugin was already in the README, the changes were minimal:

- Updated the pom.xml file with the new URL for the docs
- Changed 2 instances of master to controller, per the new terminology guidance

Please add the **hacktoberfest-accepted** label if you approve this PR. Thank you!

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
